### PR TITLE
Fix command list typing and Enter key check

### DIFF
--- a/src/components/input.tsx
+++ b/src/components/input.tsx
@@ -16,7 +16,7 @@ export const Input = ({
   clearHistory,
 }) => {
   const onSubmit = async (event: React.KeyboardEvent<HTMLInputElement>) => {
-    const commands: [string] = history
+    const commands: string[] = history
       .map(({ command }) => command)
       .filter((command: string) => command);
 
@@ -37,7 +37,7 @@ export const Input = ({
       handleTabCompletion(command, setCommand);
     }
 
-    if (event.key === 'Enter' || event.code === '13') {
+    if (event.key === 'Enter') {
       event.preventDefault();
       setLastCommandIndex(0);
       await shell(command, setHistory, clearHistory, setCommand);


### PR DESCRIPTION
## Summary
- correct the commands array typing in `Input`
- simplify Enter key detection

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_6841260cd568832f8426dc792be9d59d