### PR TITLE
Improve UI with theme toggle

### DIFF
--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,9 +1,14 @@
 import React from 'react';
 import '../styles/global.css';
 import Head from 'next/head';
+import { loadTheme } from '../utils/theme';
 
 const App = ({ Component, pageProps }) => {
   const inputRef = React.useRef<HTMLInputElement>(null);
+
+  React.useEffect(() => {
+    loadTheme();
+  }, []);
 
   const onClickAnywhere = () => {
     inputRef.current.focus();

--- a/src/utils/bin/commands.ts
+++ b/src/utils/bin/commands.ts
@@ -2,6 +2,7 @@
 
 import * as bin from './index';
 import config from '../../../config.json';
+import { applyTheme, toggleTheme } from '../theme';
 
 // Help
 export const help = async (args: string[]): Promise<string> => {
@@ -49,6 +50,7 @@ weather   - display weather
 |   Other      |
 ----------------
 repo      - open github repo
+theme     - toggle light/dark theme
 help      - display this help message
 `;
 
@@ -146,6 +148,19 @@ if you want to help, you can type 'donate'.`;
 
 export const date = async (args: string[]): Promise<string> => {
   return new Date().toString();
+};
+
+export const theme = async (args: string[]): Promise<string> => {
+  let mode = args[0];
+  if (mode !== 'light' && mode !== 'dark') {
+    mode = undefined;
+  }
+  if (!mode) {
+    mode = toggleTheme();
+  } else {
+    applyTheme(mode as 'light' | 'dark');
+  }
+  return `Switched to ${mode} theme.`;
 };
 
 // export const vi = async (args: string[]): Promise<string> => {

--- a/src/utils/theme.ts
+++ b/src/utils/theme.ts
@@ -1,0 +1,25 @@
+export type Theme = 'light' | 'dark';
+
+export const applyTheme = (theme: Theme): void => {
+  const root = document.documentElement;
+  if (theme === 'dark') {
+    root.classList.add('dark');
+  } else {
+    root.classList.remove('dark');
+  }
+  localStorage.setItem('theme', theme);
+};
+
+export const loadTheme = (): void => {
+  if (typeof window === 'undefined') return;
+  const saved = localStorage.getItem('theme') as Theme | null;
+  applyTheme(saved === 'dark' ? 'dark' : 'light');
+};
+
+export const toggleTheme = (): Theme => {
+  const current =
+    (localStorage.getItem('theme') as Theme | null) || 'light';
+  const next: Theme = current === 'light' ? 'dark' : 'light';
+  applyTheme(next);
+  return next;
+};

--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -5,7 +5,7 @@ module.exports = {
     './src/pages/**/*.{js,ts,jsx,tsx}',
     './src/components/**/*.{js,ts,jsx,tsx}',
   ],
-  darkMode: 'media', // or 'media' or 'class'
+  darkMode: 'class',
   theme: {
     colors: {
       transparent: 'transparent',


### PR DESCRIPTION
## Summary
- support manually toggled dark/light theme
- load saved theme on page load
- document new `theme` command
- enable class-based dark mode for Tailwind

## Testing
- `yarn lint` *(fails: package missing)*

------
https://chatgpt.com/codex/tasks/task_e_684127f9e224832faefa0b535b403d1c